### PR TITLE
Add benchmark utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "check_generator"
 name = "automap_test"
 
 [[bin]]
-name = "map_test"
+name = "benchmark"
 
 [dependencies]
 # egui-macroquad = { git = "https://github.com/optozorax/egui-macroquad", default-features = false, rev="dfbdb967d6cf4e4726b84a568ec1b2bdc7e4f492" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ name = "check_generator"
 [[bin]]
 name = "automap_test"
 
+[[bin]]
+name = "map_test"
+
 [dependencies]
 # egui-macroquad = { git = "https://github.com/optozorax/egui-macroquad", default-features = false, rev="dfbdb967d6cf4e4726b84a568ec1b2bdc7e4f492" }
 # macroquad = "0.4.4"

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -5,11 +5,14 @@ use std::collections::HashMap;
 use std::panic;
 use std::time::{Duration, Instant};
 
-// TODO: add cli flag for this?
-const MAX_SEED: u64 = 5;
+// TODO: add clap cli for this?
+const MAX_SEED: u64 = 100;
 const MAX_GENERATION_STEPS: usize = 200_000;
 
 fn main() {
+    // disable panic hook so they no longer get printed
+    panic::set_hook(Box::new(|_info| {}));
+
     let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 
@@ -51,7 +54,6 @@ fn main() {
                 .checked_div(valid_count)
                 .map(|v| format!("{v:?}"))
                 .unwrap_or("XXX".to_string());
-
             let error_rate = (error_count as f32) / (MAX_SEED as f32);
             let panic_rate = (panic_count as f32) / (MAX_SEED as f32);
 

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1,22 +1,20 @@
-use std::collections::HashMap;
-use std::panic;
 use gores_mapgen::config::{GenerationConfig, MapConfig};
 use gores_mapgen::generator::Generator;
 use gores_mapgen::random::Seed;
 use rand::prelude::*;
+use std::collections::HashMap;
+use std::panic;
 use std::time::Instant;
 
-
 fn main() {
-
     //thanks tobi for the code hehehe
     let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 
     let seed: u64 = random::<u64>();
-   //Loop through the keys of the hashmap 
-    for gkey  in init_gen_configs.keys(){
-        for mkey in init_map_configs.keys(){
+    //Loop through the keys of the hashmap
+    for gkey in init_gen_configs.keys() {
+        for mkey in init_map_configs.keys() {
             //We access the generate_map arguments now so the time from instant is only timing the generation function and not retreiving the data for the var also.
             let seed = Seed::from_u64(seed);
             let gen_cfg = init_gen_configs.get(gkey).unwrap();
@@ -24,16 +22,16 @@ fn main() {
 
             let now = Instant::now();
             let _ = panic::catch_unwind(|| {
-                let gen_result =  Generator::generate_map(
-                    200_000,
-                    &seed,
-                    gen_cfg,
-                    map_cfg
-                );
+                let gen_result = Generator::generate_map(200_000, &seed, gen_cfg, map_cfg);
                 let elapsed = now.elapsed(); //compare the time difference
-                match gen_result { //Handiling the Result<t,e>
-                    Ok(_) => println!("GEN {gkey} WITH {mkey} MAP GEN | ELAPSED TIME: {elapsed:?\n}"),
-                    Err(e) => println!("ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gkey} with {mkey}"),
+                match gen_result {
+                    //Handiling the Result<t,e>
+                    Ok(_) => {
+                        println!("GEN {gkey} WITH {mkey} MAP GEN | ELAPSED TIME: {elapsed:?\n}")
+                    }
+                    Err(e) => println!(
+                        "ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gkey} with {mkey}"
+                    ),
                 }
             });
         }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -13,6 +13,8 @@ fn main() {
     // disable panic hook so they no longer get printed
     panic::set_hook(Box::new(|_info| {}));
 
+    // TODO: it would be great to sort these by name, so the order of map/gen configs is
+    // consistent. But i guess this should be done in the config storage, not here.
     let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -7,30 +7,24 @@ use std::panic;
 use std::time::Instant;
 
 fn main() {
-    //thanks tobi for the code hehehe
     let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 
     let seed: u64 = random::<u64>();
-    //Loop through the keys of the hashmap
-    for gkey in init_gen_configs.keys() {
-        for mkey in init_map_configs.keys() {
-            //We access the generate_map arguments now so the time from instant is only timing the generation function and not retreiving the data for the var also.
-            let seed = Seed::from_u64(seed);
-            let gen_cfg = init_gen_configs.get(gkey).unwrap();
-            let map_cfg = init_map_configs.get(mkey).unwrap();
 
-            let now = Instant::now();
+    for (gen_config_name, gen_config) in init_gen_configs.iter() {
+        for (map_config_name, map_config) in init_map_configs.iter() {
+            let seed = Seed::from_u64(seed);
+            let start_time = Instant::now();
             let _ = panic::catch_unwind(|| {
-                let gen_result = Generator::generate_map(200_000, &seed, gen_cfg, map_cfg);
-                let elapsed = now.elapsed(); //compare the time difference
+                let gen_result = Generator::generate_map(200_000, &seed, gen_config, map_config);
+                let elapsed = start_time.elapsed(); 
                 match gen_result {
-                    //Handiling the Result<t,e>
                     Ok(_) => {
-                        println!("GEN {gkey} WITH {mkey} MAP GEN | ELAPSED TIME: {elapsed:?\n}")
+                        println!("GEN {gen_config_name} WITH {map_config_name} MAP GEN | ELAPSED TIME: {elapsed:?\n}")
                     }
                     Err(e) => println!(
-                        "ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gkey} with {mkey}"
+                        "ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gen_config_name} with {map_config_name}"
                     ),
                 }
             });

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1,33 +1,61 @@
 use gores_mapgen::config::{GenerationConfig, MapConfig};
 use gores_mapgen::generator::Generator;
 use gores_mapgen::random::Seed;
-use rand::prelude::*;
 use std::collections::HashMap;
 use std::panic;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+// TODO: add cli flag for this?
+const MAX_SEED: u64 = 5;
+const MAX_GENERATION_STEPS: usize = 200_000;
 
 fn main() {
     let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 
-    let seed: u64 = random::<u64>();
+    for (map_config_name, map_config) in init_map_configs.iter() {
+        println!("\n### Map Layout: {map_config_name}");
 
-    for (gen_config_name, gen_config) in init_gen_configs.iter() {
-        for (map_config_name, map_config) in init_map_configs.iter() {
-            let seed = Seed::from_u64(seed);
-            let start_time = Instant::now();
-            let _ = panic::catch_unwind(|| {
-                let gen_result = Generator::generate_map(200_000, &seed, gen_config, map_config);
-                let elapsed = start_time.elapsed(); 
-                match gen_result {
-                    Ok(_) => {
-                        println!("GEN {gen_config_name} WITH {map_config_name} MAP GEN | ELAPSED TIME: {elapsed:?\n}")
+        for (gen_config_name, gen_config) in init_gen_configs.iter() {
+            let mut elapsed = Duration::ZERO;
+            let mut panic_count = 0;
+            let mut error_count = 0;
+            let mut valid_count = 0;
+
+            for seed in 0..MAX_SEED {
+                let seed = Seed::from_u64(seed);
+
+                let start_time = Instant::now();
+                let generation_result = panic::catch_unwind(|| {
+                    Generator::generate_map(MAX_GENERATION_STEPS, &seed, gen_config, map_config)
+                });
+
+                match generation_result {
+                    // map was generated successfully
+                    Ok(Ok(_map)) => {
+                        elapsed += start_time.elapsed();
+                        valid_count += 1;
                     }
-                    Err(e) => println!(
-                        "ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gen_config_name} with {map_config_name}"
-                    ),
+                    // no panic, but map generation failed
+                    Ok(Err(_generation_error)) => {
+                        error_count += 1;
+                    }
+                    // map generation panic
+                    Err(_panic_info) => {
+                        panic_count += 1;
+                    }
                 }
-            });
+            }
+
+            let avg_elapsed_text = elapsed
+                .checked_div(valid_count)
+                .map(|v| format!("{v:?}"))
+                .unwrap_or("XXX".to_string());
+
+            let error_rate = (error_count as f32) / (MAX_SEED as f32);
+            let panic_rate = (panic_count as f32) / (MAX_SEED as f32);
+
+            println!("GEN {gen_config_name} | AVG_TIME={avg_elapsed_text} | ERROR_RATE={error_rate} | PANIC_RATE={panic_rate}");
         }
     }
 }

--- a/src/bin/map_test.rs
+++ b/src/bin/map_test.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::panic;
+use gores_mapgen::config::{GenerationConfig, MapConfig};
+use gores_mapgen::generator::Generator;
+use gores_mapgen::random::Seed;
+use rand::prelude::*;
+use std::time::Instant;
+
+
+fn main() {
+
+    //thanks tobi for the code hehehe
+    let init_gen_configs: HashMap<String, GenerationConfig> = GenerationConfig::get_all_configs();
+    let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
+
+    let seed: u64 = random::<u64>();
+   
+    for gkey  in init_gen_configs.keys(){
+        for mkey in init_map_configs.keys(){
+
+            let seed = Seed::from_u64(seed);
+            let gen_cfg = init_gen_configs.get(gkey).unwrap();
+            let map_cfg = init_map_configs.get(mkey).unwrap();
+
+            let now = Instant::now();
+            let _ = panic::catch_unwind(|| {
+                let gen_result =  Generator::generate_map(
+                    200_000,
+                    &seed,
+                    gen_cfg,
+                    map_cfg
+                );
+                let elapsed = now.elapsed();
+                match gen_result {
+                    Ok(_) => println!("GEN {gkey} WITH {mkey} ELAPSED TIME: {elapsed:?\n}"),
+                    Err(e) => println!("{e}"),
+                }
+            });
+        }
+    }
+}
+
+//MAKE GENERATION MAP OVER EVERY  GEN CFG & MAP CFG | MARK: DONE 
+//RNG SEED | MARK: DONE
+//TIME GENERATION  | MARK: DONE 
+//PRINT TO UI | MARK: NOT STARTED

--- a/src/bin/map_test.rs
+++ b/src/bin/map_test.rs
@@ -14,10 +14,10 @@ fn main() {
     let init_map_configs: HashMap<String, MapConfig> = MapConfig::get_all_configs();
 
     let seed: u64 = random::<u64>();
-   
+   //Loop through the keys of the hashmap 
     for gkey  in init_gen_configs.keys(){
         for mkey in init_map_configs.keys(){
-
+            //We access the generate_map arguments now so the time from instant is only timing the generation function and not retreiving the data for the var also.
             let seed = Seed::from_u64(seed);
             let gen_cfg = init_gen_configs.get(gkey).unwrap();
             let map_cfg = init_map_configs.get(mkey).unwrap();
@@ -30,17 +30,12 @@ fn main() {
                     gen_cfg,
                     map_cfg
                 );
-                let elapsed = now.elapsed();
-                match gen_result {
-                    Ok(_) => println!("GEN {gkey} WITH {mkey} ELAPSED TIME: {elapsed:?\n}"),
-                    Err(e) => println!("{e}"),
+                let elapsed = now.elapsed(); //compare the time difference
+                match gen_result { //Handiling the Result<t,e>
+                    Ok(_) => println!("GEN {gkey} WITH {mkey} MAP GEN | ELAPSED TIME: {elapsed:?\n}"),
+                    Err(e) => println!("ERROR IN GENERATING MAP: {e} | GENERATION THAT FAILED: {gkey} with {mkey}"),
                 }
             });
         }
     }
 }
-
-//MAKE GENERATION MAP OVER EVERY  GEN CFG & MAP CFG | MARK: DONE 
-//RNG SEED | MARK: DONE
-//TIME GENERATION  | MARK: DONE 
-//PRINT TO UI | MARK: NOT STARTED

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -14,8 +14,13 @@ use crate::{
 
 use macroquad::color::{colors, Color};
 
+const PRINT_TIMES: bool = false;
+
 pub fn print_time(timer: &Timer, message: &str) {
-    println!("{}: {:?}", message, timer.elapsed());
+    // TODO: add cli flag for this
+    if PRINT_TIMES {
+        println!("{}: {:?}", message, timer.elapsed());
+    }
 }
 
 pub struct Generator {


### PR DESCRIPTION
Util to test the time it takes to generate all map types and map difficulties, offers error handling that if a generation fails it states the reason it fails and on what type of generation it failed on. 